### PR TITLE
chore: set `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
This basically ensures that all pushed files use `\n` as EOL character and improves the overall consistency.