### PR TITLE
feat: allow native deno commands

### DIFF
--- a/githooks.ts
+++ b/githooks.ts
@@ -69,7 +69,9 @@ export async function setup({
   for (const h of hooks) {
     const task = githooks[h];
     const hookPath = `./.git/hooks/${h}`;
-    const hookScript = `#!/bin/sh\nexec deno task ${task}`;
+    const hookScript = `#!/bin/sh\nexec ${
+      task.startsWith("deno") ? task : `deno task ${task}`
+    }`;
 
     await Deno.writeTextFile(hookPath, hookScript);
 


### PR DESCRIPTION
This allows you to use a command instead of a task.

e.g.

```json
{
  "githooks": {
    "pre-commit": "deno fmt"
  }
}
```